### PR TITLE
fix: fail to output json with batch option 'aws'

### DIFF
--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -168,9 +168,16 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
     config: DuckConfig
   ): { command: string; items: CompileErrorItem[] } {
     const { message: stderr, info } = reason;
-    const message = config.batch === "aws" && info ? info.message : stderr;
+    const message = isBatchMode(config.batch) && info ? info.message : stderr;
     const [command, , ...messages] = message.split("\n");
     return { command, items: JSON.parse(messages.join("\n")) };
+  }
+
+  function isBatchMode(batchMode?: string) {
+    if (!batchMode) {
+      return false;
+    }
+    return ["aws", "local"].includes(batchMode);
   }
 }
 export class BuildJsCompilationError extends Error {

--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -162,21 +162,14 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
   }
   return reasons;
 
-  function deleteLogUrl(input: string[]) {
-    const messages = [...input];
-    const lastIndex = messages.length - 1;
-    let message = messages[lastIndex];
-    if (message.startsWith(":")) {
-      message = message.substring(1).trim();
-
-      try {
-        new URL(message); // check valid URL
-        messages.splice(lastIndex, 1); // delete logUrl
-      } catch (e) {
-        // do nothing
-      }
-    }
-    return messages;
+  function parseErrorReason(
+    reason: CompilerError & { info?: Record<string, any> },
+    config: DuckConfig
+  ): { command: string; items: CompileErrorItem[] } {
+    const { message: stderr, info } = reason;
+    const message = config.batch === "aws" && info ? info.message : stderr;
+    const [command, , ...messages] = message.split("\n");
+    return { command, items: JSON.parse(messages.join("\n")) };
   }
 }
 export class BuildJsCompilationError extends Error {

--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -168,16 +168,9 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
     config: DuckConfig
   ): { command: string; items: CompileErrorItem[] } {
     const { message: stderr, info } = reason;
-    const message = isBatchMode(config.batch) && info ? info.message : stderr;
+    const message = config.batch && info ? info.message : stderr;
     const [command, , ...messages] = message.split("\n");
     return { command, items: JSON.parse(messages.join("\n")) };
-  }
-
-  function isBatchMode(batchMode?: string) {
-    if (!batchMode) {
-      return false;
-    }
-    return ["aws", "local"].includes(batchMode);
   }
 }
 export class BuildJsCompilationError extends Error {

--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -161,6 +161,23 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
     throw new BuildJsCompilationError(reasons, results.length);
   }
   return reasons;
+
+  function deleteLogUrl(input: string[]) {
+    const messages = [...input];
+    const lastIndex = messages.length - 1;
+    let message = messages[lastIndex];
+    if (message.startsWith(":")) {
+      message = message.substring(1).trim();
+
+      try {
+        new URL(message); // check valid URL
+        messages.splice(lastIndex, 1); // delete logUrl
+      } catch (e) {
+        // do nothing
+      }
+    }
+    return messages;
+  }
 }
 export class BuildJsCompilationError extends Error {
   reasons: readonly ErrorReason[];


### PR DESCRIPTION
duck fails to output json report when error occurs.
The reason is that it cannot parse message including 'logUrl' to JSON.

Error message is like the below. In this case, the line `: https://ap-northeast-1.console...` is logUrl.
```
Unexpected non-JSON error: /opt/nodejs/node_modules/google-closure-compiler-linux/compiler --rewrite_polyfills=true ...
[{"level":"error","description":"The result of a goog.define call must be assigned as an isolated statement.", ...},{"level":"info","description":"70 error(s), 0 warning(s)"}]

: https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logEventViewer:group=%2Faws%2Flambda%2Ffaast-b0d763dd-d988-4d38-a357-485f28d8ef5e;stream=2020%2F01%2F30%2F%5B%24LATEST%5D12d386dbf1fe4ca9933e07671ca6956c;filter=%22575f34df-23ac-47a3-b0d9-9bb5f8a081e0%22

```

`logUrl` has been included since v3.0.14.
see the commit: https://github.com/faastjs/faast.js/commit/4c65cffa1e522e886f3948ee85b1943925e78281
So, this problem does not happen before v3.0.13.

[FaastError document](https://faastjs.org/docs/api/faastjs.faasterror) indicates the below.
`The logUrl will be appended to the end of FaastError.message and FaastError.fullStack as well.`

This PR deletes 'logUrl' from error message to be able to parse it to JSON.

