### PR TITLE
fix(cli): fix TS2783 error

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -198,7 +198,6 @@ export function run(processArgv: readonly string[]): void {
           coerce: path.resolve,
         },
         closureLibraryDir,
-        depsJs,
         ...buildDepsOptions,
         skipInitialBuild,
         port: {


### PR DESCRIPTION
This PR fixes the below error which is happened at the branch updating TS to 3.9([CI](https://app.circleci.com/pipelines/github/cybozu/duck/1993/workflows/9bbe8292-f170-4d86-9857-300b9a33a5d7/jobs/5044)):

```
src/cli.ts(201,9): error TS2783: 'depsJs' is specified more than once, so this usage will be overwritten.
```