### PR TITLE
ci: run GitHub Actions for branch push by Renovate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'renovate/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently, Renovate doesn't work as I expected. The reason is that we only run GItHub Actions for branches that has a PR, which causes a pending commit status and Renovate skips creating a PR due to the status.
I've changed to run GitHub Actions for branches that Renovate creates.