### PR TITLE
chore: fix the way to use cybozu/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@cybozu"],
+  "extends": ["github>cybozu/renovate-config"],
   "packageRules": [
     {
       "packageNames": ["google-closure-deps"],


### PR DESCRIPTION
We use cybozu/renovate-config as `@cybozu`, but it's not an official way that the document describes.
https://docs.renovatebot.com/config-presets/