### PR TITLE
chore: remove lint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/class-name-casing": "off",
     "node/no-exports-assign": "off",
-    "consistent-return": "off"
+    "consistent-return": "off",
+    "max-statements": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "no-param-reassign": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/class-name-casing": "off",
-    "node/no-exports-assign": "off"
+    "node/no-exports-assign": "off",
+    "consistent-return": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/class-name-casing": "off",
     "node/no-exports-assign": "off",
     "consistent-return": "off",
-    "max-statements": "off"
+    "max-statements": "off",
+    "no-invalid-this": "off"
   }
 }

--- a/examples/build-and-serve/js/chunks.js
+++ b/examples/build-and-serve/js/chunks.js
@@ -13,11 +13,15 @@ goog.scope(() => {
   moduleManager.setAllModuleInfo(goog.global.PLOVR_MODULE_INFO);
   const trustedModuleUris = {};
   for (const id in goog.global.PLOVR_MODULE_URIS) {
-    trustedModuleUris[id] = [
-      goog.html.legacyconversions.trustedResourceUrlFromString(
-        goog.global.PLOVR_MODULE_URIS[id]
-      ),
-    ];
+    if (
+      Object.prototype.hasOwnProperty.call(goog.global.PLOVR_MODULE_URIS, id)
+    ) {
+      trustedModuleUris[id] = [
+        goog.html.legacyconversions.trustedResourceUrlFromString(
+          goog.global.PLOVR_MODULE_URIS[id]
+        ),
+      ];
+    }
   }
   moduleManager.setModuleTrustedUris(trustedModuleUris);
   moduleManager.getModuleInfo("chunks").setLoaded();

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -25,16 +25,19 @@ export async function getFaastCompiler(
   logger.info("Initializing batch mode");
   const batch = assertNonNullable(config.batch);
   const batchOptions = getBatchOptions(config);
-  const m =
-    batch === "aws"
-      ? await faastAws(compilerFaastFunctions, batchOptions as AwsOptions)
-      : batch === "local"
-      ? await faastLocal(compilerFaastFunctions, batchOptions as LocalOptions)
-      : null;
-  if (!m) {
-    throw new TypeError(`Unsupported batch mode: ${batch}`);
+  return getFaastModule(batch, batchOptions);
+}
+
+async function getFaastModule(
+  batch: "aws" | "local",
+  batchOptions: AwsOptions | LocalOptions
+) {
+  if (batch === "aws") {
+    return faastAws(compilerFaastFunctions, batchOptions as AwsOptions);
+  } else if (batch === "local") {
+    return faastLocal(compilerFaastFunctions, batchOptions as LocalOptions);
   }
-  return m;
+  throw new TypeError(`Unsupported batch mode: ${batch}`);
 }
 
 function getBatchOptions(config: DuckConfig): AwsOptions | LocalOptions {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -48,7 +48,9 @@ function createBaseOptions(
   if (entryConfig["experimental-compiler-options"]) {
     const expOpts = entryConfig["experimental-compiler-options"];
     for (const key in expOpts) {
-      opts[snakeCase(key)] = expOpts[key];
+      if (Object.prototype.hasOwnProperty.call(expOpts, key)) {
+        opts[snakeCase(key)] = expOpts[key];
+      }
     }
   }
 
@@ -412,9 +414,11 @@ export function convertModuleInfos(
   const moduleInfo: { [id: string]: string[] } = {};
   const moduleUris: { [id: string]: string[] } = {};
   for (const id in modules) {
-    const module = modules[id];
-    moduleInfo[id] = module.deps.slice();
-    moduleUris[id] = createModuleUris(id);
+    if (Object.prototype.hasOwnProperty.call(modules, id)) {
+      const module = modules[id];
+      moduleInfo[id] = module.deps.slice();
+      moduleUris[id] = createModuleUris(id);
+    }
   }
   return { moduleInfo, moduleUris };
 }

--- a/src/entryconfig.ts
+++ b/src/entryconfig.ts
@@ -159,16 +159,18 @@ async function loadInheritedJson(
 function normalize(json: any): EntryConfig {
   if (json.modules) {
     for (const id in json.modules) {
-      const module = json.modules[id];
-      if (!module.inputs) {
-        throw new TypeError(`No module inputs: ${id}`);
-      } else if (!Array.isArray(module.inputs)) {
-        module.inputs = [module.inputs];
-      }
-      if (!module.deps) {
-        module.deps = [];
-      } else if (!Array.isArray(module.deps)) {
-        module.deps = [module.deps];
+      if (Object.prototype.hasOwnProperty.call(json.modules, id)) {
+        const module = json.modules[id];
+        if (!module.inputs) {
+          throw new TypeError(`No module inputs: ${id}`);
+        } else if (!Array.isArray(module.inputs)) {
+          module.inputs = [module.inputs];
+        }
+        if (!module.deps) {
+          module.deps = [];
+        } else if (!Array.isArray(module.deps)) {
+          module.deps = [module.deps];
+        }
       }
     }
   }
@@ -181,8 +183,10 @@ function normalize(json: any): EntryConfig {
 export function createDag(entryConfig: EntryConfig): Dag {
   const chunkNodes: Node[] = [];
   for (const id in entryConfig.modules) {
-    const chunk = entryConfig.modules[id];
-    chunkNodes.push(new Node(id, chunk.deps));
+    if (Object.prototype.hasOwnProperty.call(entryConfig.modules, id)) {
+      const chunk = entryConfig.modules[id];
+      chunkNodes.push(new Node(id, chunk.deps));
+    }
   }
   return new Dag(chunkNodes);
 }


### PR DESCRIPTION
Preparation of #592

**before:**

```sh
  $  npm run lint

> @cybozu/duck@0.32.8 lint
> eslint --ext js,ts src test types examples


/duck/examples/build-and-serve/js/chunks.js
  15:3  warning  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in

/duck/src/batch.ts
  29:5  warning  Do not nest ternary expressions  no-nested-ternary

/duck/src/commands/buildJs.ts
  83:9  warning  Async arrow function expected no return value  consistent-return

/duck/src/commands/serve.ts
  197:18  warning  Expected to return a value at the end of async function 'replyChunksCompile'  consistent-return

/duck/src/compiler-core.ts
  125:70  warning  Expected to return a value at the end of arrow function  consistent-return

/duck/src/compiler.ts
   42:1  warning  Function 'createBaseOptions' has too many statements (62). Maximum allowed is 40                            max-statements
   50:5  warning  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  414:3  warning  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in

/duck/src/entryconfig.ts
  161:5  warning  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  183:3  warning  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in

/duck/test/bin-test/bin.js
  12:5  warning  Unexpected 'this'  no-invalid-this

✖ 11 problems (0 errors, 11 warnings)
```

**after:**

```sh
  $  npm run lint

> @cybozu/duck@0.32.8 lint
> eslint --ext js,ts src test types examples
```