### PR TITLE
Show friendly message for missing entryConfigDir

### DIFF
--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -38,7 +38,11 @@ export async function buildJs(
   let restoringDepsJs: Promise<void> | null = null;
   const entryConfigPaths = entryConfigs
     ? entryConfigs
-    : (await findEntryConfigs(assertString(config.entryConfigDir))).sort();
+    : (
+        await findEntryConfigs(
+          assertString(config.entryConfigDir, '"entryConfigDir" is required')
+        )
+      ).sort();
   const limit = pLimit(config.concurrency || 1);
   let runningJobCount = 1;
   let completedJobCount = 1;


### PR DESCRIPTION
Currently, if `entryConfigDir` is not specified, the following error occurs. This doesn't tell us anything about what is going on.
```
  $  npx duck build
  ↓ Compile Soy templates [skipped]
  ✔ Generate deps.js
  ✖ Compile JS files
    → Should be string: undefined
TypeError: Should be string: undefined
```