### PR TITLE
chore: enable cache for npm on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "14"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'renovate/**'
+      - "renovate/**"
   pull_request:
 
 jobs:
@@ -15,34 +15,34 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies
-      run: npm ci
-    - name: Test
-      run: npm test
-    - name: Test examples
-      run: |
-        cd examples/build-and-serve
-        npm i
-        npm run build:ci
-    - name: Test in the oldest Google Closure Tools
-      run: |
-        npm i --no-save google-closure-compiler@20180910 google-closure-deps@20190325
-        OLDEST_COMPILER=1 npm run unit
-    - name: Test examples in the oldest Google Closure Tools
-      run: |
-        cd examples/build-and-serve
-        npm i --no-save google-closure-library@20180910
-        npm run build:ci 
-    - name: Report coverage to codecov
-      if: matrix.node-version == '12.x'
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: npx codecov
 
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm test
+      - name: Test examples
+        run: |
+          cd examples/build-and-serve
+          npm i
+          npm run build:ci
+      - name: Test in the oldest Google Closure Tools
+        run: |
+          npm i --no-save google-closure-compiler@20180910 google-closure-deps@20190325
+          OLDEST_COMPILER=1 npm run unit
+      - name: Test examples in the oldest Google Closure Tools
+        run: |
+          cd examples/build-and-serve
+          npm i --no-save google-closure-library@20180910
+          npm run build:ci
+      - name: Report coverage to codecov
+        if: matrix.node-version == '12.x'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: npx codecov


### PR DESCRIPTION
ref: https://github.com/actions/setup-node#caching-packages-dependencies

Now we can enable cache for npm dependencies with `actions/setup-node@v2`