### PR TITLE
chore(deps): update typescript to v4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "prettier": "2.7.1",
         "rimraf": "^3.0.2",
         "standard-version": "^9.3.2",
-        "typescript": "^4.2.4"
+        "typescript": "~4.5.5"
       },
       "engines": {
         "node": ">=16"
@@ -12512,9 +12512,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23494,9 +23494,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prettier": "2.7.1",
     "rimraf": "^3.0.2",
     "standard-version": "^9.3.2",
-    "typescript": "^4.2.4"
+    "typescript": "~4.5.5"
   },
   "homepage": "https://github.com/cybozu/duck",
   "repository": {

--- a/src/commands/buildDeps.ts
+++ b/src/commands/buildDeps.ts
@@ -19,8 +19,8 @@ export async function buildDeps(config: DuckConfig): Promise<void> {
   if (config.depsJs) {
     try {
       await fs.writeFile(config.depsJs, fileText);
-    } catch (error) {
-      if (error.code === "ENOENT") {
+    } catch (error: unknown) {
+      if ((error as any)?.code === "ENOENT") {
         await fs.mkdir(path.dirname(config.depsJs), { recursive: true });
         await fs.writeFile(config.depsJs, fileText);
       } else {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -307,8 +307,8 @@ export async function serve(config: DuckConfig, watch = true) {
     const { host, port } = config;
     try {
       await server.listen(port, host);
-    } catch (err) {
-      server.log.error(err);
+    } catch (err: unknown) {
+      server.log.error(err as any);
       process.exit(1);
     }
   };

--- a/test/compiler-output.ts
+++ b/test/compiler-output.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "assert";
-import path from "path";
 import fs from "fs";
+import path from "path";
 import tempy from "tempy";
 import { CompilerOutput, compileToJson } from "../src/compiler";
 import { CompileErrorItem } from "../src/report";
@@ -82,7 +82,8 @@ describe("compiler output", () => {
             js_output_file: "out.js",
           },
         });
-      } catch (err) {
+      } catch (err: any) {
+        assert(err instanceof Error);
         const [f, s, ...r] = err.message.split("\n");
         first = f;
         second = s;


### PR DESCRIPTION
Update to `~4.5.5` instead `^4.5.5`.
Cannot easily update to TS 4.6+.
See https://github.com/cybozu/duck/issues/720