### PR TITLE
fix(soy)!: remove soyOptions.inputPrefix for old closure-templates option

### DIFF
--- a/src/commands/cleanSoy.ts
+++ b/src/commands/cleanSoy.ts
@@ -6,12 +6,8 @@ import { logger } from "../logger";
 export type CleanSoyConfig = Required<Pick<DuckConfig, "soyOptions">>;
 
 export async function cleanSoy(config: CleanSoyConfig): Promise<string> {
-  const { outputPathFormat, inputPrefix } = config.soyOptions;
-  let outputPath = outputPathFormat;
-  if (inputPrefix) {
-    outputPath = outputPath.replace("{INPUT_PREFIX}", inputPrefix);
-  }
-  outputPath = outputPath
+  const { outputPathFormat } = config.soyOptions;
+  const outputPath = outputPathFormat
     .replace("{INPUT_DIRECTORY}", "/**/")
     .replace("{INPUT_FILE_NAME}", "*")
     .replace("{INPUT_FILE_NAME_NO_EXT}", "*")

--- a/src/duckconfig.ts
+++ b/src/duckconfig.ts
@@ -59,17 +59,6 @@ export function loadConfig(opts: any = {}): DuckConfig {
     toAbsPathArray(config, configDir, "soyClasspaths");
     config.soyClasspaths = config.soyClasspaths || [];
     toAbsPathArray(config, configDir, "soyFileRoots");
-    if (config.soyOptions) {
-      const { inputPrefix } = config.soyOptions;
-      if (inputPrefix) {
-        toAbsPath(config.soyOptions, configDir, "inputPrefix");
-        // path.resolve() removes a trailing separator,
-        // but it's important for `inputPrefix`.
-        if (inputPrefix.endsWith(path.sep)) {
-          config.soyOptions.inputPrefix += path.sep;
-        }
-      }
-    }
     if (config.https) {
       assertString(
         config.https.keyPath,

--- a/src/soy.ts
+++ b/src/soy.ts
@@ -1,12 +1,10 @@
 import execa from "execa";
-import path from "path";
 import { resultInfoLogType } from "./cli";
 import { DuckConfig } from "./duckconfig";
 import { logger } from "./logger";
 
 export interface SoyToJsOptions {
   outputPathFormat: string;
-  inputPrefix?: string;
   shouldGenerateGoogMsgDefs?: boolean;
   shouldGenerateJsdoc?: boolean;
   shouldProvideRequireSoyNamespaces?: boolean;
@@ -58,10 +56,6 @@ export function toSoyArgs(
       throw new TypeError(`Unsupported soy config value: "${key}: ${value}"`);
     }
   });
-  if (soyOptions.inputPrefix) {
-    const { inputPrefix } = soyOptions;
-    soyFiles = soyFiles.map((filepath) => path.relative(inputPrefix, filepath));
-  }
   args.push("--srcs", soyFiles.join(","));
   return args;
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -95,16 +95,11 @@ function calcOutputPath(
   inputPath: string,
   config: Required<Pick<DuckConfig, "soyOptions">>
 ) {
-  const { outputPathFormat, inputPrefix } = config.soyOptions;
-  let outputPath = outputPathFormat;
-  let inputDirectory = path.dirname(inputPath);
-  if (inputPrefix) {
-    inputDirectory = path.relative(inputPrefix, inputDirectory);
-    outputPath = outputPath.replace("{INPUT_PREFIX}", inputPrefix);
-  }
+  const { outputPathFormat } = config.soyOptions;
+  const inputDirectory = path.dirname(inputPath);
   const filename = path.basename(inputPath);
   const filenameNoExt = filename.slice(0, -path.extname(filename).length);
-  return outputPath
+  return outputPathFormat
     .replace("{INPUT_DIRECTORY}", inputDirectory)
     .replace("{INPUT_FILE_NAME}", filename)
     .replace("{INPUT_FILE_NAME_NO_EXT}", filenameNoExt);

--- a/test/soy.ts
+++ b/test/soy.ts
@@ -30,30 +30,5 @@ describe("soy", () => {
         "/js/foo.soy,/js/bar.soy",
       ]);
     });
-    it("inputPrefix", () => {
-      const config = {
-        soyFileRoots: [],
-        soyJarPath: "/soy.jar",
-        soyClasspaths: [],
-        soyOptions: {
-          outputPathFormat: "/out",
-          inputPrefix: "/path/to/js/",
-        },
-      };
-      assert.deepEqual(
-        toSoyArgs(["/path/to/js/foo.soy", "/path/to/js/bar/baz.soy"], config),
-        [
-          "-classpath",
-          "/soy.jar",
-          "com.google.template.soy.SoyToJsSrcCompiler",
-          "--outputPathFormat",
-          "/out",
-          "--inputPrefix",
-          "/path/to/js/",
-          "--srcs",
-          "foo.soy,bar/baz.soy",
-        ]
-      );
-    });
   });
 });


### PR DESCRIPTION
Removed in https://github.com/google/closure-templates/commit/88c3d5b1e467d03bc6b3924e1069a9f43f48de79, closure-templates `2019-03-07` release.