### PR TITLE
fix(duckconfig): remove validation logic for unsupported old compiler

### DIFF
--- a/src/duckconfig.ts
+++ b/src/duckconfig.ts
@@ -159,15 +159,6 @@ export function loadConfig(opts: any = {}): DuckConfig {
     result.concurrency = 1000;
   }
 
-  if (result.batch) {
-    const { version } = compilerPakageJson;
-    if (!semver.satisfies(version, ">=20180716")) {
-      throw new Error(
-        `Installed google-closure-compiler@${version} is too old for batch mode. Use v20180716 or later.`
-      );
-    }
-  }
-
   if (result.batchAwsCustomCompiler) {
     if (!result.batchAwsCustomCompiler.name) {
       throw new TypeError(


### PR DESCRIPTION
No longer necessary because currently support `>=20180910.1.0`.

https://github.com/cybozu/duck/blob/bf3515cde06b041238f4d5321a557880072d2815/package.json#L63