### PR TITLE
fix(batch): make the `webpackAwsSdk` option available in batchOptions

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -101,7 +101,6 @@ function defaultBatchOptions(config: DuckConfig): AwsOptions {
     },
     webpackOptions: {
       externals: [
-        /^aws-sdk\/?/,
         "google-closure-compiler-js",
         "google-closure-compiler-linux",
         "google-closure-compiler-osx",


### PR DESCRIPTION
faast.js has added support for Node.js 18.x by adding the `webpackAwsSdk` option. If you set it to `true`, AWS SDK v2 will be bundled by webpack. However, duck will override this option because `/^aws-sdk/?/` is included in the externals of webpackOptions by default.This PR fixes that.