### PR TITLE
fix: pin tempy to 3.0.0 to prevent a webpack error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "semver": "^7.5.4",
         "split2": "^4.2.0",
         "strip-json-comments": "^5.0.1",
-        "tempy": "^3.0.0",
+        "tempy": "3.0.0",
         "workerpool": "^6.4.2",
         "xmlbuilder": "^15.1.1",
         "yargs": "^17.7.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "semver": "^7.5.4",
     "split2": "^4.2.0",
     "strip-json-comments": "^5.0.1",
-    "tempy": "^3.0.0",
+    "tempy": "3.0.0",
     "workerpool": "^6.4.2",
     "xmlbuilder": "^15.1.1",
     "yargs": "^17.7.2",


### PR DESCRIPTION
close https://github.com/cybozu/duck/pull/864

The latest `tempy@3.1.0` has `temp-dir@3` in the deps.
https://github.com/sindresorhus/tempy/commit/5a4cb2b63db90cc353b5c649a0a59419432c8d00

`temp-dir@3` includes top-level await.
https://github.com/sindresorhus/temp-dir/blob/v3.0.0/index.js

But `webpack@4` in `faastjs@6` doesn't allow it and duck throws an error for batch compilation.
ref: https://github.com/cybozu/duck/actions/runs/5952268350/job/16143868194?pr=864