### PR TITLE
ci: add token for codecov v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,5 @@ jobs:
         if: matrix.node-version == '18.17.x'
         uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)


### PR DESCRIPTION
[codecov-action](https://github.com/codecov/codecov-action) v4 requires token.

ref: https://github.com/cybozu/duck/pull/993