### PR TITLE
docs: fix examples raw mode

### DIFF
--- a/examples/.eslintrc.json
+++ b/examples/.eslintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     "dot-notation": "off",
     "node/no-exports-assign": "off",
+    "node/no-unsupported-features/es-builtins": "off",
     "node/no-unsupported-features/es-syntax": "off",
     "node/no-unsupported-features/node-builtins": "off"
   },

--- a/examples/build-js/bootstrap.js
+++ b/examples/build-js/bootstrap.js
@@ -4,18 +4,20 @@
   let url;
   if (mode.toLowerCase() === "compiled") {
     url = new URL(location.origin);
-    if (basename === "chunks") {
-      url.pathname = "/build/chunks/chunks.js";
-    } else {
-      url.pathname = `/build/${basename}.js`;
-    }
+    url.pathname = `/build/${basename}.js`;
   } else {
+    // dev server
     const params = new URLSearchParams();
     params.set("id", basename);
     params.set("mode", mode.toUpperCase());
     url = new URL("http://localhost:9810/compile");
     // url = new URL("https://localhost:9810/compile");
     url.search = params.toString();
+  }
+  if (mode.toUpperCase() === "RAW") {
+    globalThis.CLOSURE_DEFINES = {
+      "goog.ENABLE_DEBUG_LOADER": true,
+    };
   }
   document.write(`<script src="${url}"></script>`);
   const h1 = document.querySelector("h1");

--- a/examples/build-soy/bootstrap.js
+++ b/examples/build-soy/bootstrap.js
@@ -4,18 +4,20 @@
   let url;
   if (mode.toLowerCase() === "compiled") {
     url = new URL(location.origin);
-    if (basename === "chunks") {
-      url.pathname = "/build/chunks/chunks.js";
-    } else {
-      url.pathname = `/build/${basename}.js`;
-    }
+    url.pathname = `/build/${basename}.js`;
   } else {
+    // dev server
     const params = new URLSearchParams();
     params.set("id", basename);
     params.set("mode", mode.toUpperCase());
     url = new URL("http://localhost:9810/compile");
     // url = new URL("https://localhost:9810/compile");
     url.search = params.toString();
+  }
+  if (mode.toUpperCase() === "RAW") {
+    globalThis.CLOSURE_DEFINES = {
+      "goog.ENABLE_DEBUG_LOADER": true,
+    };
   }
   document.write(`<script src="${url}"></script>`);
   const h1 = document.querySelector("h1");


### PR DESCRIPTION
enable `goog.ENABLE_DEBUG_LOADER` in RAW mode for the latest closure-library.