### PR TITLE
fix(soy): list all dependency soy files on incremental compilation

### DIFF
--- a/test/fixtures/listSoyDependencies/1.soy
+++ b/test/fixtures/listSoyDependencies/1.soy
@@ -1,0 +1,2 @@
+import { foo } from '2.soy';
+  import * as bar from "4.soy";

--- a/test/fixtures/listSoyDependencies/2.soy
+++ b/test/fixtures/listSoyDependencies/2.soy
@@ -1,0 +1,6 @@
+import {
+  bar,
+  baz
+} from '3.soy';
+
+{export extern foo: () => string}{/extern}

--- a/test/fixtures/listSoyDependencies/3.soy
+++ b/test/fixtures/listSoyDependencies/3.soy
@@ -1,0 +1,4 @@
+import {bar} from '4.soy';
+
+{export extern bar: () => string}{/extern}
+{export extern baz: () => string}{/extern}

--- a/test/fixtures/listSoyDependencies/4.soy
+++ b/test/fixtures/listSoyDependencies/4.soy
@@ -1,0 +1,1 @@
+// import {foo} from '5.soy';

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { strict as assert } from "assert";
+import { describe, it } from "vitest";
+import { listSoyDependencies } from "../src/watch.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const fixturesBaseDir = path.join(__dirname, "fixtures");
+
+describe("listSoyDependencies", () => {
+  const fixturesDir = path.join(fixturesBaseDir, "listSoyDependencies");
+
+  it("lists all the dependencies", async () => {
+    const actual = await listSoyDependencies(
+      path.join(fixturesDir, "1.soy"),
+      fixturesDir,
+    );
+    assert.deepEqual(actual, [
+      path.join(fixturesDir, "1.soy"),
+      path.join(fixturesDir, "2.soy"),
+      path.join(fixturesDir, "4.soy"),
+      path.join(fixturesDir, "3.soy"),
+    ]);
+  });
+
+  it("returns the given file with no dependencies", async () => {
+    const actual = await listSoyDependencies(
+      path.join(fixturesDir, "4.soy"),
+      fixturesDir,
+    );
+    assert.deepEqual(actual, [path.join(fixturesDir, "4.soy")]);
+  });
+});


### PR DESCRIPTION
On incremental compilation, only the changed file is specified for the `--srcs` flag. However, the closure compiler does not lookup the dependency file  unless they are not specified in `--srcs` (at least in the current depending version). We are annoyed by the issue that duck aborts the watch mode when a soy file is updated.